### PR TITLE
Exception handle property reads

### DIFF
--- a/src/RoslynPad.Common/Runtime/ResultObject.cs
+++ b/src/RoslynPad.Common/Runtime/ResultObject.cs
@@ -10,6 +10,8 @@ using RoslynPad.Utilities;
 
 namespace RoslynPad.Runtime
 {
+    using System.Reflection;
+
     public sealed class ResultObject : NotificationObject
     {
         private readonly object _o;
@@ -99,7 +101,17 @@ namespace RoslynPad.Runtime
 
             if (_property != null)
             {
-                var value = _property.GetValue(_o);
+                object value;
+                try
+                {
+                    value = _property.GetValue(_o);
+                }
+                catch (TargetInvocationException exception)
+                {
+                     _header = $"{_property.Name} = Threw {exception.InnerException.GetType().Name}";
+                    return;
+                }
+
                 _header = _property.Name + " = " + value;
                 var propertyType = _property.PropertyType;
                 if (!propertyType.IsPrimitive &&

--- a/src/RoslynPad.Common/Runtime/ResultObject.cs
+++ b/src/RoslynPad.Common/Runtime/ResultObject.cs
@@ -109,6 +109,7 @@ namespace RoslynPad.Runtime
                 catch (TargetInvocationException exception)
                 {
                      _header = $"{_property.Name} = Threw {exception.InnerException.GetType().Name}";
+                    _children = new[] { new ResultObject(exception.InnerException) };
                     return;
                 }
 

--- a/src/RoslynPad.Roslyn/RoslynPad.Roslyn.csproj
+++ b/src/RoslynPad.Roslyn/RoslynPad.Roslyn.csproj
@@ -37,68 +37,68 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.3.0-beta1-20160301-05\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.3.0-beta1-20160323-02\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.3.0-beta1-20160301-05\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.3.0-beta1-20160323-02\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
       <Aliases>global,workspaces</Aliases>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/src/RoslynPad.Roslyn/packages.config
+++ b/src/RoslynPad.Roslyn/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Features" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Features" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="System.AppContext" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections" version="4.0.10" targetFramework="net46" />

--- a/src/RoslynPad.RoslynEditor/RoslynPad.RoslynEditor.csproj
+++ b/src/RoslynPad.RoslynEditor/RoslynPad.RoslynEditor.csproj
@@ -41,31 +41,31 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/src/RoslynPad.RoslynEditor/packages.config
+++ b/src/RoslynPad.RoslynEditor/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AvalonEdit" version="5.0.2" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160301-05" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160323-02" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="System.Collections" version="4.0.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />

--- a/src/RoslynPad/RoslynPad.csproj
+++ b/src/RoslynPad/RoslynPad.csproj
@@ -65,67 +65,67 @@
       <HintPath>..\packages\AvalonEdit.5.0.2\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.3.0-beta1-20160301-05\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.3.0-beta1-20160323-02\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.3.0-beta1-20160301-05\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.3.0-beta1-20160323-02\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160301-05\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.1.3.0-beta1-20160323-02\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Features, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Features.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Features.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160301-05\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.0-beta1-20160323-02\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet">

--- a/src/RoslynPad/packages.config
+++ b/src/RoslynPad/packages.config
@@ -2,21 +2,21 @@
 <packages>
   <package id="AvalonEdit" version="5.0.2" targetFramework="net45" />
   <package id="Extended.Wpf.Toolkit" version="2.6" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Features" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160301-05" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Features" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Features" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.0-beta1-20160323-02" targetFramework="net461" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net461" />
   <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net461" />
   <package id="System.AppContext" version="4.0.0" targetFramework="net461" />


### PR DESCRIPTION
Firstly I've updated Microsoft.CodeAnalysis references to the latest nightlies as the nightly versions in the master branch are no longer available on roslyn nightly NuGet.

I've added handling of reading properties in the tree results panel. An example of this is dumping the CurrentAppDomain. The properties will now say they've thrown an exception of [x] type.