### PR TITLE
avoid "out of index" using caretPosition

### DIFF
--- a/src/RoslynPad.Roslyn/Completion/Providers/AbstractReferenceDirectiveCompletionProvider.cs
+++ b/src/RoslynPad.Roslyn/Completion/Providers/AbstractReferenceDirectiveCompletionProvider.cs
@@ -27,7 +27,7 @@ namespace RoslynPad.Roslyn.Completion.Providers
 
         public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
         {
-            return PathCompletionUtilities.IsTriggerCharacter(text, caretPosition);
+            return PathCompletionUtilities.IsTriggerCharacter(text, caretPosition - 1);
         }
 
         private static TextSpan GetTextChangeSpan(SyntaxToken stringLiteral, int position)


### PR DESCRIPTION
to repro try to digit a char on an empty pad file
previous version was IsTriggerCharacter working with characterPosition