### PR TITLE
Cancellation using Thread.Abort

### DIFF
--- a/src/RoslynPad.Hosting/IExecutionHost.cs
+++ b/src/RoslynPad.Hosting/IExecutionHost.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using RoslynPad.Roslyn;
+using RoslynPad.Runtime;
+
+namespace RoslynPad.Hosting 
+{
+    internal interface IExecutionHost : IDisposable 
+    {
+        Platform Platform { get; set; }
+
+        Task<ExceptionResultObject> ExecuteAsync(string code, CancellationToken ct = default(CancellationToken));
+
+        Task CompileAndSave(string code, string assemblyPath);
+
+        event Action<IList<ResultObject>> Dumped;
+
+        Task ResetAsync();
+    }
+}

--- a/src/RoslynPad.Hosting/RoslynPad.Hosting.csproj
+++ b/src/RoslynPad.Hosting/RoslynPad.Hosting.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExecutionHost.cs" />
+    <Compile Include="IExecutionHost.cs" />
     <Compile Include="NuGetScriptMetadataResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/RoslynPad.Roslyn/RoslynHost.cs
+++ b/src/RoslynPad.Roslyn/RoslynHost.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
@@ -40,6 +41,7 @@ namespace RoslynPad.Roslyn
             typeof(ObjectExtensions),
             typeof(Path),
             typeof(Assembly),
+            typeof(MessageBox),
         }.ToImmutableArray();
 
         private static readonly ImmutableArray<Assembly> _defaultReferenceAssemblies =

--- a/src/RoslynPad/OpenDocumentViewModel.cs
+++ b/src/RoslynPad/OpenDocumentViewModel.cs
@@ -25,7 +25,7 @@ namespace RoslynPad
         private readonly string _workingDirectory;
         private readonly Dispatcher _dispatcher;
 
-        private ExecutionHost _executionHost;
+        private IExecutionHost _executionHost;
         private ObservableCollection<ResultObject> _results;
         private CancellationTokenSource _cts;
         private bool _isRunning;
@@ -61,7 +61,7 @@ namespace RoslynPad
                 : MainViewModel.DocumentRoot.Path;
 
             Platform = Platform.X86;
-            _executionHost = new ExecutionHost(GetHostExeName(), _workingDirectory,
+            _executionHost = new ExecutionHost(Platform, _workingDirectory,
                 roslynHost.DefaultReferences.OfType<PortableExecutableReference>().Select(x => x.FilePath),
                 roslynHost.DefaultImports, mainViewModel.NuGetConfiguration);
 
@@ -130,19 +130,6 @@ namespace RoslynPad
             MainViewModel.RoslynHost.UpdateDocument(formattedDocument);
         }
 
-        private string GetHostExeName()
-        {
-            switch (Platform)
-            {
-                case Platform.X86:
-                    return "RoslynPad.Host32.exe";
-                case Platform.X64:
-                    return "RoslynPad.Host64.exe";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(Platform));
-            }
-        }
-
         public Platform Platform
         {
             get { return _platform; }
@@ -152,7 +139,8 @@ namespace RoslynPad
                 {
                     if (_executionHost != null)
                     {
-                        _executionHost.HostPath = GetHostExeName();
+                        _executionHost.Platform = value;
+                        
                         RestartHostCommand.Execute();
                     }
                 }


### PR DESCRIPTION
This addresses #45. I can get messages from the script below, however cannot understand yet where to wait for dumped messages so that they are also printed.

```
using System.Threading.Tasks;
using System.Threading;
using System.Windows;
var cts = new CancellationTokenSource();
var token = cts.Token;
try
{
    var t = Task.Run(() =>
     {
         try
         {
             var c = 0L;
             while (!token.IsCancellationRequested)
             {
                 c++;
                 if (c % 100000000 == 0)
                 {
                     Console.WriteLine(c);
                 }
             }
         }
         catch (Exception e)
         {
             Console.WriteLine(e.Message);
         }
     }, token);

    Thread.Sleep(50000);
    cts.Cancel();
}
catch (ThreadAbortException ex)
{
    MessageBox.Show("Thread is aborting");
    Console.WriteLine("Thread is aborting");
    cts.Cancel();
}
finally
{
    MessageBox.Show("Finished");
    Console.WriteLine("Finished");
}
```
