### PR TITLE
Fix FormatException during startup => Use InvariantCulture when calling Rect.ToString()

### DIFF
--- a/src/RoslynPad/MainWindow.xaml.cs
+++ b/src/RoslynPad/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Composition.Hosting;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
@@ -100,7 +101,7 @@ namespace RoslynPad
 
         private void SaveWindowLayout()
         {
-            Properties.Settings.Default.WindowBounds = RestoreBounds.ToString();
+            Properties.Settings.Default.WindowBounds = RestoreBounds.ToString(CultureInfo.InvariantCulture);
             Properties.Settings.Default.WindowState = WindowState.ToString();
         }
 


### PR DESCRIPTION
Use InvariantCulture when calling Rect.ToString() so that bounds are always persisted in invariant format: `"x,y,width,height"` instead of `"x;y;width;height"` (format depends on current culture)

Fixes `System.FormatException` when calling Rect.Parse(..) during app startup in LoadWindowLayout() on my machine.