### PR TITLE
Support additional default referenced assembly locations

### DIFF
--- a/src/RoslynPad.Roslyn/RoslynHost.cs
+++ b/src/RoslynPad.Roslyn/RoslynHost.cs
@@ -72,7 +72,9 @@ namespace RoslynPad.Roslyn
 
         #region Constructors
 
-        public RoslynHost(NuGetConfiguration nuGetConfiguration = null, IEnumerable<Assembly> additionalAssemblies = null)
+        public RoslynHost(NuGetConfiguration nuGetConfiguration = null, 
+            IEnumerable<Assembly> additionalAssemblies = null, 
+            IEnumerable<string> additionalReferencedAssemblyLocations = null)
         {
             _nuGetConfiguration = nuGetConfiguration;
 
@@ -110,17 +112,19 @@ namespace RoslynPad.Roslyn
             (_referenceAssembliesPath, _documentationPath) = GetReferenceAssembliesPath();
             _documentationProviderService = new DocumentationProviderServiceFactory.DocumentationProviderService();
 
-            DefaultReferences = GetMetadataReferences();
+            DefaultReferences = GetMetadataReferences(additionalReferencedAssemblyLocations);
 
             DefaultImports = _defaultReferenceAssemblyTypes.Select(x => x.Namespace).Distinct().ToImmutableArray();
 
             GetService<IDiagnosticService>().DiagnosticsUpdated += OnDiagnosticsUpdated;
         }
 
-        private ImmutableArray<MetadataReference> GetMetadataReferences()
+        private ImmutableArray<MetadataReference> GetMetadataReferences(IEnumerable<string> additionalReferencedAssemblyLocations = null)
         {
             // allow facade assemblies to take precedence
-            var dictionary = _defaultReferenceAssemblies.Select(x => x.Location)
+            var dictionary = _defaultReferenceAssemblies
+                .Select(x => x.Location)
+                .Concat(additionalReferencedAssemblyLocations ?? Enumerable.Empty<string>())
                 .ToImmutableDictionary(Path.GetFileNameWithoutExtension)
                 .SetItems(TryGetFacadeAssemblies()
                     .ToImmutableDictionary(Path.GetFileNameWithoutExtension));


### PR DESCRIPTION
I need this argument so that I can provide default assemblies referenced as if via `#r`. Current parameter `additionalAssemblies` is used for other things and I couldn't find another way to do so. It is important that this parameter works with locations as strings and not another `IEnumerable<Assembly>`, otherwise unsigned assemblies will not work and will throw on loading into a signed process. The name `additionalDefaultReferencedAssemblyLocations` is very long but very precise on what it is :)