### PR TITLE
Added tabbed results for viewing as grid (current) or as text 

### DIFF
--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -22,6 +22,8 @@ using RoslynPad.Utilities;
 
 namespace RoslynPad.UI
 {
+    using System.Diagnostics;
+    
     [Export]
     public class OpenDocumentViewModel : NotificationObject
     {
@@ -42,7 +44,6 @@ namespace RoslynPad.UI
         private Func<TextSpan> _getSelection;
 
         public IEnumerable<object> Results => _results;
-
         private ObservableCollection<ResultObject> ResultsInternal
         {
             // ReSharper disable once UnusedMember.Local
@@ -79,6 +80,7 @@ namespace RoslynPad.UI
             CommentSelectionCommand = commands.CreateAsync(() => CommentUncommentSelection(CommentAction.Comment));
             UncommentSelectionCommand = commands.CreateAsync(() => CommentUncommentSelection(CommentAction.Uncomment));
             RenameSymbolCommand = commands.CreateAsync(RenameSymbol);
+
         }
 
         public void SetDocument(DocumentViewModel document)
@@ -360,6 +362,7 @@ namespace RoslynPad.UI
             try
             {
                 await Task.Run(() => _executionHost.CompileAndSave(code, saveDialog.FileName)).ConfigureAwait(true);
+                OnPropertyChanged(nameof(Results));
             }
             catch (CompilationErrorException ex)
             {
@@ -403,11 +406,15 @@ namespace RoslynPad.UI
             {
                 var code = await GetCode(cancellationToken).ConfigureAwait(true);
                 var errorResult = await _executionHost.ExecuteAsync(code).ConfigureAwait(true);
+
+                OnPropertyChanged(nameof(Results));
+
                 _onError?.Invoke(errorResult);
                 if (errorResult != null)
                 {
                     results.Add(errorResult);
                 }
+
             }
             catch (CompilationErrorException ex)
             {

--- a/src/RoslynPad/App.xaml
+++ b/src/RoslynPad/App.xaml
@@ -18,7 +18,8 @@
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <formatting:BooleanToVisibilityConverter x:Key="BooleanToVisibilityHiddenConverter"
                                                      FalseValue="Hidden" />
-
+            <formatting:ResultsFlatteningConverter x:Key="ResultsFlatteningConverter" />
+            
             <ControlTemplate x:Key="ErrorTemplate">
                 <Border BorderBrush="Red"
                         ToolTip="{Binding AdornedElement.(Validation.Errors)[0].ErrorContent, ElementName=controlWithError}"

--- a/src/RoslynPad/DocumentView.xaml
+++ b/src/RoslynPad/DocumentView.xaml
@@ -8,7 +8,7 @@
              xmlns:ui="clr-namespace:RoslynPad.UI;assembly=RoslynPad.Common.UI"
              xmlns:editor="clr-namespace:RoslynPad.Editor.Windows;assembly=RoslynPad.Editor.Windows"
              xmlns:runtime="clr-namespace:RoslynPad.Runtime;assembly=RoslynPad.Common"
-             mc:Ignorable="d"
+    mc:Ignorable="d"
              d:DataContext="{d:DesignInstance ui:OpenDocumentViewModel}">
     <FrameworkElement.InputBindings>
         <KeyBinding Key="F5"
@@ -204,125 +204,155 @@
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch" />
 
-            <DockPanel Grid.Column="0"
-                       Grid.Row="3"
-                       Grid.IsSharedSizeScope="True">
-                <ScrollViewer DockPanel.Dock="Top"
+            <TabControl  TabStripPlacement="Bottom" 
+                             HorizontalAlignment="Stretch" 
+                             VerticalAlignment="Stretch" 
+                             Grid.Column="0"
+                    Grid.Row="3"
+                    Grid.IsSharedSizeScope="True">
+
+                <TabItem Header="Results (Grid)" 
+                             HorizontalAlignment="Stretch" 
+                             VerticalAlignment="Stretch">
+                    <StackPanel HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch">
+                        <ScrollViewer DockPanel.Dock="Top"
                               Name="HeaderScroll"
                               HorizontalScrollBarVisibility="Hidden"
                               VerticalScrollBarVisibility="Disabled">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="150"
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="150"
                                               SharedSizeGroup="ResultNameGroup" />
-                            <ColumnDefinition Width="1" />
-                            <ColumnDefinition Width="450"
+                                    <ColumnDefinition Width="1" />
+                                    <ColumnDefinition Width="450"
                                               SharedSizeGroup="ResultValueGroup" />
-                            <ColumnDefinition Width="1" />
-                            <ColumnDefinition Width="Auto"
+                                    <ColumnDefinition Width="1" />
+                                    <ColumnDefinition Width="Auto"
                                               SharedSizeGroup="ResultTypeGroup" />
-                            <ColumnDefinition Width="1" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="Name"
+                                    <ColumnDefinition Width="1" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Name"
                                    Margin="20 0 20 0"
                                    HorizontalAlignment="Center"
                                    Grid.Column="0" />
-                        <GridSplitter Grid.Column="1"
+                                <GridSplitter Grid.Column="1"
                                       ResizeBehavior="PreviousAndNext"
                                       ResizeDirection="Columns"
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       Background="DarkGray" />
-                        <TextBlock Text="Value"
+                                <TextBlock Text="Value"
                                    Margin="20 0 20 0"
                                    HorizontalAlignment="Center"
                                    Grid.Column="2" />
-                        <GridSplitter Grid.Column="3"
+                                <GridSplitter Grid.Column="3"
                                       ResizeBehavior="PreviousAndNext"
                                       ResizeDirection="Columns"
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       Background="DarkGray" />
-                        <TextBlock Text="Type"
+                                <TextBlock Text="Type"
                                    Margin="20 0 20 0"
                                    HorizontalAlignment="Center"
                                    Grid.Column="4" />
-                        <GridSplitter Grid.Column="5"
+                                <GridSplitter Grid.Column="5"
                                       ResizeBehavior="PreviousAndCurrent"
                                       ResizeDirection="Columns"
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       Background="DarkGray" />
-                    </Grid>
-                </ScrollViewer>
-                <controls:TreeListView ItemsSource="{Binding Results}"
+                            </Grid>
+                        </ScrollViewer>
+                        <controls:TreeListView ItemsSource="{Binding Results}"
                                        ScrollViewer.VerticalScrollBarVisibility="Auto"
                                        VirtualizingPanel.IsVirtualizing="True"
                                        VirtualizingPanel.VirtualizationMode="Recycling"
                                        BorderBrush="#cccccc"
                                        ScrollViewer.ScrollChanged="ScrollViewer_OnScrollChanged">
-                    <ItemsControl.ItemTemplate>
-                        <HierarchicalDataTemplate ItemsSource="{Binding Children, Mode=OneTime}"
+                            <ItemsControl.ItemTemplate>
+                                <HierarchicalDataTemplate ItemsSource="{Binding Children, Mode=OneTime}"
                                                   DataType="runtime:ResultObject">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition SharedSizeGroup="ResultNameGroup" />
-                                    <ColumnDefinition Width="1" />
-                                    <ColumnDefinition SharedSizeGroup="ResultValueGroup" />
-                                    <ColumnDefinition Width="1" />
-                                    <ColumnDefinition SharedSizeGroup="ResultTypeGroup" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.ContextMenu>
-                                    <ContextMenu>
-                                        <MenuItem Header="Copy Value"
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition SharedSizeGroup="ResultNameGroup" />
+                                            <ColumnDefinition Width="1" />
+                                            <ColumnDefinition SharedSizeGroup="ResultValueGroup" />
+                                            <ColumnDefinition Width="1" />
+                                            <ColumnDefinition SharedSizeGroup="ResultTypeGroup" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="Copy Value"
                                                   Click="CopyClick">
-                                            <MenuItem.Icon>
-                                                <Image Source="{StaticResource Copy}"
+                                                    <MenuItem.Icon>
+                                                        <Image Source="{StaticResource Copy}"
                                                        ToolTip="Copy Value"
                                                        Height="12" />
-                                            </MenuItem.Icon>
-                                        </MenuItem>
-                                        <MenuItem Header="Copy All"
+                                                    </MenuItem.Icon>
+                                                </MenuItem>
+                                                <MenuItem Header="Copy All"
                                                   Tag="All"
                                                   Click="CopyClick" />
-                                    </ContextMenu>
-                                </Grid.ContextMenu>
-                                <DockPanel Grid.Column="0">
-                                    <ToggleButton Style="{StaticResource TreeListViewToggleStyle}" />
-                                    <Button Padding="0"
+                                            </ContextMenu>
+                                        </Grid.ContextMenu>
+                                        <DockPanel Grid.Column="0">
+                                            <ToggleButton Style="{StaticResource TreeListViewToggleStyle}" />
+                                            <Button Padding="0"
                                             Margin="2 0 5 0"
                                             VerticalAlignment="Top"
                                             KeyboardNavigation.IsTabStop="False"
                                             Background="Transparent"
                                             BorderBrush="Transparent"
                                             Click="CopyClick">
-                                        <Image Source="{StaticResource Copy}"
+                                                <Image Source="{StaticResource Copy}"
                                                ToolTip="Copy Value"
                                                Height="12" />
-                                    </Button>
-                                    <TextBlock Text="{Binding Header, Mode=OneTime}" />
-                                </DockPanel>
-                                <TextBlock Grid.Column="2"
+                                            </Button>
+                                            <TextBlock Text="{Binding Header, Mode=OneTime}" />
+                                        </DockPanel>
+                                        <TextBlock Grid.Column="2"
                                            Text="{Binding Value, Mode=OneTime}"
                                            TextWrapping="Wrap"
                                            Margin="{Binding Path=Level, Mode=OneTime, Converter={StaticResource LevelToIndentConverter}, RelativeSource={RelativeSource AncestorType=controls:TreeListViewItem}}" />
-                                <TextBlock Grid.Column="4"
+                                        <TextBlock Grid.Column="4"
                                            TextWrapping="Wrap"
                                            Text="{Binding Type, Mode=OneTime}"
                                            Margin="{Binding Path=Level, Mode=OneTime, Converter={StaticResource LevelToIndentConverter}, RelativeSource={RelativeSource AncestorType=controls:TreeListViewItem}}" />
-                            </Grid>
-                        </HierarchicalDataTemplate>
-                    </ItemsControl.ItemTemplate>
-                    <ItemsControl.ItemContainerStyle>
-                        <Style TargetType="controls:TreeListViewItem"
+                                    </Grid>
+                                </HierarchicalDataTemplate>
+                            </ItemsControl.ItemTemplate>
+                            <ItemsControl.ItemContainerStyle>
+                                <Style TargetType="controls:TreeListViewItem"
                                BasedOn="{StaticResource {x:Type controls:TreeListViewItem}}">
-                            <EventSetter Event="KeyDown"
+                                    <EventSetter Event="KeyDown"
                                          Handler="OnTreeViewKeyDown" />
-                        </Style>
-                    </ItemsControl.ItemContainerStyle>
-                </controls:TreeListView>
-            </DockPanel>
+                                </Style>
+                            </ItemsControl.ItemContainerStyle>
+                        </controls:TreeListView>
+                    </StackPanel>
+                </TabItem>
+                <TabItem  Header="Results (Text)" 
+                          HorizontalAlignment="Stretch" 
+                          VerticalAlignment="Stretch">
+                    <TextBox 
+                        Name="ResultsText"
+                        IsReadOnly="True" 
+                        IsReadOnlyCaretVisible="True"
+                        TextWrapping="NoWrap" 
+                        HorizontalAlignment="Stretch" 
+                        VerticalAlignment="Stretch"
+                        Width="Auto"
+                        Height="Auto"
+                        BorderThickness="0" 
+                        TextAlignment="Left"
+                        HorizontalScrollBarVisibility="Auto"
+                        VerticalScrollBarVisibility="Auto"
+                        Text="{Binding Results, Mode=OneWay,  Converter={StaticResource ResultsFlatteningConverter}}">
+                    </TextBox>
+                </TabItem>
+            </TabControl>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/src/RoslynPad/Formatting/ResultsFlatteningConverter.cs
+++ b/src/RoslynPad/Formatting/ResultsFlatteningConverter.cs
@@ -1,0 +1,41 @@
+﻿namespace RoslynPad.Formatting
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Data;
+    using Runtime;
+
+    [ValueConversion(typeof(object), typeof(string))]
+    public class ResultsFlatteningConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+            var results = value as ObservableCollection<ResultObject>;
+            if (results == null)
+            {
+                var type = value.GetType().ToString();
+                var msg = $"{GetType().FullName} requires something castable to ObservableCollection<ResultObject> as a source. '{type}' isnt.";
+                Debug.WriteLine(msg);
+                return null;
+                //throw new ArgumentException(msg,nameof(value));
+            }
+
+            var returnValue = string.Join(Environment.NewLine, results.Select(r => r.Value));
+            Debug.WriteLine($"{DateTime.Now.ToLongTimeString()} - {GetType().FullName} was given {results.Count} items");
+            Debug.WriteLine($"{DateTime.Now.ToLongTimeString()} - {GetType().FullName} is returning {returnValue}");
+            return returnValue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException("This should not be convertable");
+        }
+    }
+}

--- a/src/RoslynPad/RoslynPad.csproj
+++ b/src/RoslynPad/RoslynPad.csproj
@@ -89,6 +89,7 @@
     </Compile>
     <Compile Include="FolderBrowserDialogAdapter.cs" />
     <Compile Include="Formatting\BooleanToVisibilityConverter.cs" />
+    <Compile Include="Formatting\ResultsFlatteningConverter.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Formatting\CodeActionsConverter.cs" />
     <Compile Include="Formatting\CodeActionToGlyphConverter.cs" />


### PR DESCRIPTION
Adds a tabbed results for grid and text.  Covers what I was asking about in #96 

![image](https://cloud.githubusercontent.com/assets/15381181/25314824/f617df48-2818-11e7-80f5-608d8be873c5.png)

![image](https://cloud.githubusercontent.com/assets/15381181/25314827/03daa232-2819-11e7-81d7-b1a822f4fbc2.png)
