### PR TITLE
Updated to support Roslyn version 2.6.1

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,9 +3,9 @@
 		<Features>strict</Features>
 		<Deterministic>True</Deterministic>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-		<EditorPackageVersion>1.0.4</EditorPackageVersion>
-		<RoslynPackageVersion>2.4.0</RoslynPackageVersion>
-		<RoslynAssemblyVersion>2.4.0.0</RoslynAssemblyVersion>
+		<EditorPackageVersion>1.0.5</EditorPackageVersion>
+		<RoslynPackageVersion>2.6.0</RoslynPackageVersion>
+		<RoslynAssemblyVersion>2.6.0.0</RoslynAssemblyVersion>
 		<LangVersion>latest</LangVersion>
 		<Authors>Eli Arbel</Authors>
 		<PackageProjectUrl>https://github.com/aelij/RoslynPad</PackageProjectUrl>

--- a/build/common.props
+++ b/build/common.props
@@ -4,8 +4,8 @@
 		<Deterministic>True</Deterministic>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<EditorPackageVersion>1.0.5</EditorPackageVersion>
-		<RoslynPackageVersion>2.6.0</RoslynPackageVersion>
-		<RoslynAssemblyVersion>2.6.0.0</RoslynAssemblyVersion>
+		<RoslynPackageVersion>2.6.1</RoslynPackageVersion>
+		<RoslynAssemblyVersion>2.6.1.0</RoslynAssemblyVersion>
 		<LangVersion>latest</LangVersion>
 		<Authors>Eli Arbel</Authors>
 		<PackageProjectUrl>https://github.com/aelij/RoslynPad</PackageProjectUrl>

--- a/src/RoslynPad.Roslyn/Completion/Providers/AbstractLoadDirectiveCompletionProvider.cs
+++ b/src/RoslynPad.Roslyn/Completion/Providers/AbstractLoadDirectiveCompletionProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace RoslynPad.Roslyn.Completion.Providers
 {

--- a/src/RoslynPad.Roslyn/Completion/Providers/AbstractReferenceDirectiveCompletionProvider.cs
+++ b/src/RoslynPad.Roslyn/Completion/Providers/AbstractReferenceDirectiveCompletionProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace RoslynPad.Roslyn.Completion.Providers
 {

--- a/src/RoslynPad.Roslyn/Completion/Providers/FileSystemCompletionHelper.cs
+++ b/src/RoslynPad.Roslyn/Completion/Providers/FileSystemCompletionHelper.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace RoslynPad.Roslyn
 {

--- a/src/RoslynPad.Roslyn/Completion/Providers/GlobalAssemblyCacheCompletionHelper.cs
+++ b/src/RoslynPad.Roslyn/Completion/Providers/GlobalAssemblyCacheCompletionHelper.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace RoslynPad.Roslyn.Completion.Providers
 {

--- a/src/RoslynPad.Roslyn/RoslynPad.Roslyn.csproj
+++ b/src/RoslynPad.Roslyn/RoslynPad.Roslyn.csproj
@@ -5,17 +5,17 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
-    <InternalsAssemblyNames>Microsoft.CodeAnalysis.CSharp;Microsoft.CodeAnalysis.Features;Microsoft.CodeAnalysis.CSharp.Features;Microsoft.CodeAnalysis.Scripting;Microsoft.CodeAnalysis.CSharp.Scripting;Microsoft.CodeAnalysis.Workspaces;Microsoft.CodeAnalysis.CSharp.Workspaces</InternalsAssemblyNames>
+    <InternalsAssemblyNames>Microsoft.CodeAnalysis.CSharp;Microsoft.CodeAnalysis.Features;Microsoft.CodeAnalysis.CSharp.Features;Microsoft.CodeAnalysis.Scripting;Microsoft.CodeAnalysis.CSharp.Scripting;Microsoft.CodeAnalysis.Workspaces;Microsoft.CodeAnalysis.CSharp.Workspaces;Microsoft.CodeAnalysis.Extensions;Microsoft.CodeAnalysis.PooledObjects</InternalsAssemblyNames>
     <Version>$(RoslynAssemblyVersion)</Version>
     <PackageVersion>$(RoslynPackageVersion)</PackageVersion>
     <Description>Exposes many Roslyn editor services that are currently internal. The version of this package corresponds to the Roslyn packages.</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.4.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />


### PR DESCRIPTION
#178 This functionally works to support version 2.6.1 of Roslyn although there may be a better way of resolving the problems with FixAllState.Create being removed by MS. 