### PR TITLE
Regex substitution in Find & Replace

### DIFF
--- a/src/RoslynPad.Editor.Windows.Test/RoslynPad.Editor.Windows.Test.csproj
+++ b/src/RoslynPad.Editor.Windows.Test/RoslynPad.Editor.Windows.Test.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RoslynPad.Editor.Windows\RoslynPad.Editor.Windows.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+</Project>

--- a/src/RoslynPad.Editor.Windows.Test/RoslynPad.Editor.Windows.Test.csproj
+++ b/src/RoslynPad.Editor.Windows.Test/RoslynPad.Editor.Windows.Test.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Xunit.StaFact" Version="0.2.17" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RoslynPad.Editor.Windows\RoslynPad.Editor.Windows.csproj" />

--- a/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
+++ b/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
@@ -1,16 +1,15 @@
 ﻿using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Editing;
-using NUnit.Framework;
-using System.Threading;
+using Xunit;
 
 namespace RoslynPad.Editor.Windows.Test
 {
-    [TestFixture, Apartment(ApartmentState.STA)]
     public class SearchReplacePanelTests
     {
-        [TestCase("one two two three", "two", 4, 5)]
-        [TestCase("one two two three", "two", 5, 9)]
-        [TestCase("one two two three", "two", 17, 5)]
+        [WpfTheory]
+        [InlineData("one two two three", "two", 17, 5)]
+        [InlineData("one two two three", "two", 4, 5)]
+        [InlineData("one two two three", "two", 5, 9)]
         public void FindNext_WithNoSelection_SelectsExpectedMatch(string documentText, string searchPattern, int caretOffset, int expectedSelectionStartColumn)
         {
             var textArea = new TextArea { Document = new TextDocument(documentText) };
@@ -25,12 +24,12 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.FindNext();
 
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(expectedSelectionStartColumn));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(searchPattern.Length));
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(expectedSelectionStartColumn, textArea.Selection.StartPosition.Column);
+            Assert.Equal(searchPattern.Length, textArea.Selection.Length);
         }
 
-        [Test]
+        [WpfFact]
         public void FindNext_WithMatchSelectedAndCaretAtStartOfMatch_SelectsNextMatch()
         {
             var textArea = new TextArea { Document = new TextDocument("one two two three") };
@@ -45,14 +44,15 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.FindNext();
 
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(9));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(9, textArea.Selection.StartPosition.Column);
+            Assert.Equal(3, textArea.Selection.Length);
         }
 
-        [TestCase("one two two three", "two", 11, 9)]
-        [TestCase("one two two three", "two", 10, 5)]
-        [TestCase("one two two three", "two", 0, 9)]
+        [WpfTheory]
+        [InlineData("one two two three", "two", 11, 9)]
+        [InlineData("one two two three", "two", 10, 5)]
+        [InlineData("one two two three", "two", 0, 9)]
         public void FindPrevious_WithNoSelection_SelectsExpectedMatch(string documentText, string searchPattern, int caretOffset, int expectedSelectionStartColumn)
         {
             var textArea = new TextArea { Document = new TextDocument(documentText) };
@@ -67,12 +67,12 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.FindPrevious();
 
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(expectedSelectionStartColumn));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(searchPattern.Length));
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(expectedSelectionStartColumn, textArea.Selection.StartPosition.Column);
+            Assert.Equal(searchPattern.Length, textArea.Selection.Length);
         }
 
-        [Test]
+        [WpfFact]
         public void FindPrevious_WithMatchSelectedAndCaretAtEndOfMatch_SelectsPreviousMatch()
         {
             var textArea = new TextArea { Document = new TextDocument("one two two three") };
@@ -88,12 +88,12 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.FindPrevious();
 
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(5));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(5, textArea.Selection.StartPosition.Column);
+            Assert.Equal(3, textArea.Selection.Length);
         }
 
-        [Test]
+        [WpfFact]
         public void ReplaceNext_WithNoSelection_SelectsNextMatch()
         {
             var textArea = new TextArea { Document = new TextDocument("one two three") };
@@ -109,12 +109,12 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.ReplaceNext();
 
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(5));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(5, textArea.Selection.StartPosition.Column);
+            Assert.Equal(3, textArea.Selection.Length);
         }
 
-        [Test]
+        [WpfFact]
         public void ReplaceNext_WithMatchSelected_ReplacesMatchAndSelectsNextMatch()
         {
             var textArea = new TextArea { Document = new TextDocument("one two three two") };
@@ -131,13 +131,13 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.ReplaceNext();
 
-            Assert.That(textArea.Document.Text, Is.EqualTo("one 2 three two"));
-            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(13));
-            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+            Assert.Equal("one 2 three two", textArea.Document.Text);
+            Assert.Equal(1, textArea.Selection.StartPosition.Line);
+            Assert.Equal(13, textArea.Selection.StartPosition.Column);
+            Assert.Equal(3, textArea.Selection.Length);
         }
 
-        [Test]
+        [WpfFact]
         public void ReplaceNext_WithMatchSelectedAndUsingRegularExpression_ReplacesMatchWithRegexSubstitution()
         {
             var textArea = new TextArea { Document = new TextDocument("one two three") };
@@ -155,10 +155,10 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.ReplaceNext();
 
-            Assert.That(textArea.Document.Text, Is.EqualTo("one twotwo three"));
+            Assert.Equal("one twotwo three", textArea.Document.Text);
         }
 
-        [Test]
+        [WpfFact]
         public void ReplaceAll_UsingRegularExpressions_ReplacesAllMatchesWithRegexSubstitution()
         {
             var textArea = new TextArea { Document = new TextDocument("one two three") };
@@ -173,7 +173,7 @@ namespace RoslynPad.Editor.Windows.Test
 
             searchReplacePanel.ReplaceAll();
 
-            Assert.That(textArea.Document.Text, Is.EqualTo("oonee twoo threeee"));
+            Assert.Equal("oonee twoo threeee", textArea.Document.Text);
         }
     }
 }

--- a/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
+++ b/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
@@ -1,0 +1,51 @@
+﻿using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Editing;
+using NUnit.Framework;
+using System.Threading;
+
+namespace RoslynPad.Editor.Windows.Test
+{
+    [TestFixture, Apartment(ApartmentState.STA)]
+    public class SearchReplacePanelTests
+    {
+        [Test]
+        public void ReplaceNext_WhenNoResultSelected_SelectsNextResult()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two three four") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "two";
+            searchReplacePanel.IsReplaceMode = true;
+
+            textArea.ClearSelection();
+
+            searchReplacePanel.ReplaceNext();
+
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(5));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void ReplaceNext_WhenResultSelected_ReplacesResultAndSelectsNext()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two one two") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "two";
+            searchReplacePanel.ReplacePattern = "2";
+            searchReplacePanel.IsReplaceMode = true;
+
+            searchReplacePanel.ReplaceNext();
+
+            Assert.That(textArea.Document.Text, Is.EqualTo("one 2 one two"));
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(11));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+        }
+    }
+}

--- a/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
+++ b/src/RoslynPad.Editor.Windows.Test/SearchReplacePanelTests.cs
@@ -8,10 +8,95 @@ namespace RoslynPad.Editor.Windows.Test
     [TestFixture, Apartment(ApartmentState.STA)]
     public class SearchReplacePanelTests
     {
-        [Test]
-        public void ReplaceNext_WhenNoResultSelected_SelectsNextResult()
+        [TestCase("one two two three", "two", 4, 5)]
+        [TestCase("one two two three", "two", 5, 9)]
+        [TestCase("one two two three", "two", 17, 5)]
+        public void FindNext_WithNoSelection_SelectsExpectedMatch(string documentText, string searchPattern, int caretOffset, int expectedSelectionStartColumn)
         {
-            var textArea = new TextArea { Document = new TextDocument("one two three four") };
+            var textArea = new TextArea { Document = new TextDocument(documentText) };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = searchPattern;
+
+            textArea.ClearSelection();
+            textArea.Caret.Offset = caretOffset;
+
+            searchReplacePanel.FindNext();
+
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(expectedSelectionStartColumn));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(searchPattern.Length));
+        }
+
+        [Test]
+        public void FindNext_WithMatchSelectedAndCaretAtStartOfMatch_SelectsNextMatch()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two two three") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "two";
+
+            textArea.Selection = Selection.Create(textArea, 4, 7);
+            textArea.Caret.Offset = 4;
+
+            searchReplacePanel.FindNext();
+
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(9));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+        }
+
+        [TestCase("one two two three", "two", 11, 9)]
+        [TestCase("one two two three", "two", 10, 5)]
+        [TestCase("one two two three", "two", 0, 9)]
+        public void FindPrevious_WithNoSelection_SelectsExpectedMatch(string documentText, string searchPattern, int caretOffset, int expectedSelectionStartColumn)
+        {
+            var textArea = new TextArea { Document = new TextDocument(documentText) };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = searchPattern;
+
+            textArea.ClearSelection();
+            textArea.Caret.Offset = caretOffset;
+
+            searchReplacePanel.FindPrevious();
+
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(expectedSelectionStartColumn));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(searchPattern.Length));
+        }
+
+        [Test]
+        public void FindPrevious_WithMatchSelectedAndCaretAtEndOfMatch_SelectsPreviousMatch()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two two three") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "two";
+            searchReplacePanel.FindNext();
+
+            textArea.Selection = Selection.Create(textArea, 8, 11);
+            textArea.Caret.Offset = 11;
+
+            searchReplacePanel.FindPrevious();
+
+            Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(5));
+            Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void ReplaceNext_WithNoSelection_SelectsNextMatch()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two three") };
 
             var searchReplacePanel = SearchReplacePanel.Install(textArea);
 
@@ -20,6 +105,7 @@ namespace RoslynPad.Editor.Windows.Test
             searchReplacePanel.IsReplaceMode = true;
 
             textArea.ClearSelection();
+            textArea.Caret.Offset = 0;
 
             searchReplacePanel.ReplaceNext();
 
@@ -29,9 +115,9 @@ namespace RoslynPad.Editor.Windows.Test
         }
 
         [Test]
-        public void ReplaceNext_WhenResultSelected_ReplacesResultAndSelectsNext()
+        public void ReplaceNext_WithMatchSelected_ReplacesMatchAndSelectsNextMatch()
         {
-            var textArea = new TextArea { Document = new TextDocument("one two one two") };
+            var textArea = new TextArea { Document = new TextDocument("one two three two") };
 
             var searchReplacePanel = SearchReplacePanel.Install(textArea);
 
@@ -40,12 +126,54 @@ namespace RoslynPad.Editor.Windows.Test
             searchReplacePanel.ReplacePattern = "2";
             searchReplacePanel.IsReplaceMode = true;
 
+            textArea.Selection = Selection.Create(textArea, 4, 7);
+            textArea.Caret.Offset = 4;
+
             searchReplacePanel.ReplaceNext();
 
-            Assert.That(textArea.Document.Text, Is.EqualTo("one 2 one two"));
+            Assert.That(textArea.Document.Text, Is.EqualTo("one 2 three two"));
             Assert.That(textArea.Selection.StartPosition.Line, Is.EqualTo(1));
-            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(11));
+            Assert.That(textArea.Selection.StartPosition.Column, Is.EqualTo(13));
             Assert.That(textArea.Selection.Length, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void ReplaceNext_WithMatchSelectedAndUsingRegularExpression_ReplacesMatchWithRegexSubstitution()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two three") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "(two)";
+            searchReplacePanel.ReplacePattern = "$1$1";
+            searchReplacePanel.IsReplaceMode = true;
+            searchReplacePanel.UseRegex = true;
+
+            textArea.Selection = Selection.Create(textArea, 4, 7);
+            textArea.Caret.Offset = 4;
+
+            searchReplacePanel.ReplaceNext();
+
+            Assert.That(textArea.Document.Text, Is.EqualTo("one twotwo three"));
+        }
+
+        [Test]
+        public void ReplaceAll_UsingRegularExpressions_ReplacesAllMatchesWithRegexSubstitution()
+        {
+            var textArea = new TextArea { Document = new TextDocument("one two three") };
+
+            var searchReplacePanel = SearchReplacePanel.Install(textArea);
+
+            searchReplacePanel.Open();
+            searchReplacePanel.SearchPattern = "([aeiou])";
+            searchReplacePanel.ReplacePattern = "$1$1";
+            searchReplacePanel.IsReplaceMode = true;
+            searchReplacePanel.UseRegex = true;
+
+            searchReplacePanel.ReplaceAll();
+
+            Assert.That(textArea.Document.Text, Is.EqualTo("oonee twoo threeee"));
         }
     }
 }

--- a/src/RoslynPad.Editor.Windows/SearchReplacePanel.cs
+++ b/src/RoslynPad.Editor.Windows/SearchReplacePanel.cs
@@ -333,10 +333,10 @@ namespace RoslynPad.Editor
             _textArea.TextView.InvalidateLayer(KnownLayer.Selection);
         }
 
-        void SelectResult(ISearchResult textSement)
+        void SelectResult(ISearchResult searchResult)
         {
-            _textArea.Caret.Offset = textSement.Offset;
-            _textArea.Selection = Selection.Create(_textArea, textSement.Offset, textSement.EndOffset);
+            _textArea.Caret.Offset = searchResult.Offset;
+            _textArea.Selection = Selection.Create(_textArea, searchResult.Offset, searchResult.EndOffset);
             _textArea.Caret.BringCaretToView();
             // show caret even if the editor does not have the Keyboard Focus
             _textArea.Caret.Show();

--- a/src/RoslynPad.Editor.Windows/SearchReplacePanel.cs
+++ b/src/RoslynPad.Editor.Windows/SearchReplacePanel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -477,11 +476,24 @@ namespace RoslynPad.Editor
         {
             if (!IsReplaceMode) return;
 
-            FindNext();
-            if (!_textArea.Selection.IsEmpty)
+            var selectedResult = GetSelectedResult();
+            if (selectedResult != null)
             {
                 _textArea.Selection.ReplaceSelectionWithText(ReplacePattern ?? string.Empty);
             }
+
+            FindNext();
+        }
+
+        private TextSegment GetSelectedResult()
+        {
+            if (_textArea.Selection.IsEmpty)
+                return null;
+
+            var selectionStartOffset = _textArea.Document.GetOffset(_textArea.Selection.StartPosition.Location);
+            var selectionLength = _textArea.Selection.Length;
+            return _renderer.CurrentResults.FirstOrDefault(r => r.StartOffset == selectionStartOffset
+                                                             && r.Length == selectionLength);
         }
 
         public void ReplaceAll()

--- a/src/RoslynPad.sln
+++ b/src/RoslynPad.sln
@@ -39,6 +39,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Hosting", "Hosting", "{E219
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Roslyn", "Roslyn", "{33A4C07C-3BBB-4BA5-8A4E-CC22883B8ED5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoslynPad.Editor.Windows.Test", "RoslynPad.Editor.Windows.Test\RoslynPad.Editor.Windows.Test.csproj", "{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		RoslynPad.Editor.Shared\RoslynPad.Editor.Shared.projitems*{7fb0604b-44cd-4db1-99c5-e89ea6c20aec}*SharedItemsImports = 13
@@ -100,6 +102,10 @@ Global
 		{DF39838A-357C-44C7-9B14-4A99EA2A8210}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF39838A-357C-44C7-9B14-4A99EA2A8210}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF39838A-357C-44C7-9B14-4A99EA2A8210}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -117,6 +123,7 @@ Global
 		{7FB0604B-44CD-4DB1-99C5-E89EA6C20AEC} = {09BCD791-CCF8-48DB-98E4-6B18105D2DDB}
 		{8A9BFF57-9025-4BBC-B77C-C85937528210} = {09BCD791-CCF8-48DB-98E4-6B18105D2DDB}
 		{DF39838A-357C-44C7-9B14-4A99EA2A8210} = {E219D424-5BAA-483A-BFE6-679BA2A3C9B0}
+		{B3080E72-B24C-40A8-9AD6-08D7AC99B8C4} = {09BCD791-CCF8-48DB-98E4-6B18105D2DDB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E595517-397C-4164-83BB-D80FC9B19D36}


### PR DESCRIPTION
Fixes #166

This is the issue I was aiming at when I came across #208 so I've branched off my solution for that.

I'll try to outline what I've done -

The `ISearchResult`s RoslynPad gets back from AvalonEdit already seem to support regex substitution, but we're casting them to `TextSegment`s and `TextSegment`s don't support regex substitution.

So I changed to storing the ISearchResults without casting them.

This meant they can no longer be stored in AvalonEdit's `TextSegmentCollection` which provided methods used by our `FindNext` / `FindPrevious` methods, so I've written tests for those and re-implemented them. 

The behaviour of `FindNext` / `FindPrevious` has changed very slightly e.g. if the caret is directly before a match and I press 'Find Next' then that match will now be selected like happens in Visual Studio; previously that match was skipped and the match after that one was selected. I've implemented `Find Previous` as the reverse of `Find Next`.

Actually implementing the regex substitution was just a case of making use of the `ReplaceWith` method from the `ISearchResult`.