### PR TITLE
Implement restore nuget packages menuitem command

### DIFF
--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -121,7 +121,7 @@ namespace RoslynPad.UI
             UncommentSelectionCommand = commands.CreateAsync(() => CommentUncommentSelection(CommentAction.Uncomment));
             RenameSymbolCommand = commands.CreateAsync(RenameSymbol);
             ToggleLiveModeCommand = commands.Create(() => IsLiveMode = !IsLiveMode);
-            RestoreNugetPackagesCommand = commands.Create(() => RestoreNugetPackages());
+            RestoreNugetPackagesCommand = commands.Create(async () => await UpdatePackages());
 
             ILText = DefaultILText;
         }
@@ -465,11 +465,6 @@ namespace RoslynPad.UI
         public IDelegateCommand RenameSymbolCommand { get; }
 
         public IDelegateCommand RestoreNugetPackagesCommand { get;  }
-
-        public void RestoreNugetPackages()
-        {
-
-        }
 
         public bool IsRunning
         {

--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -121,6 +121,7 @@ namespace RoslynPad.UI
             UncommentSelectionCommand = commands.CreateAsync(() => CommentUncommentSelection(CommentAction.Uncomment));
             RenameSymbolCommand = commands.CreateAsync(RenameSymbol);
             ToggleLiveModeCommand = commands.Create(() => IsLiveMode = !IsLiveMode);
+            RestoreNugetPackagesCommand = commands.Create(() => RestoreNugetPackages());
 
             ILText = DefaultILText;
         }
@@ -462,6 +463,13 @@ namespace RoslynPad.UI
         public IDelegateCommand UncommentSelectionCommand { get; }
 
         public IDelegateCommand RenameSymbolCommand { get; }
+
+        public IDelegateCommand RestoreNugetPackagesCommand { get;  }
+
+        public void RestoreNugetPackages()
+        {
+
+        }
 
         public bool IsRunning
         {

--- a/src/RoslynPad/DocumentView.xaml
+++ b/src/RoslynPad/DocumentView.xaml
@@ -210,6 +210,7 @@
                 <Menu Background="Transparent">
                     <MenuItem Header="{Binding NuGet, Mode=OneTime}"
                               ItemsSource="{Binding RestoreErrors}"
+                              Command="{Binding RestoreNugetPackagesCommand}"
                               ToolTip="NuGet Restore">
                         <MenuItem.HeaderTemplate>
                             <DataTemplate DataType="{x:Type ui:NuGetDocumentViewModel}">


### PR DESCRIPTION
I'm having a problem getting nuget packages to restore when I open a csx.  I haven't figured out why yet, but noticed you had a "Nuget Restore" menuitem, but I can't see that it's implemented.  I'm probably missing something, but in case I'm not I'm making this pull request to hook up that menu item to UpdatePackages