### PR TITLE
Layout tweaks and multicore JIT for the WPF app.

### DIFF
--- a/src/RoslynPad.NetCore/MainWindow.xaml
+++ b/src/RoslynPad.NetCore/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿x<Window xmlns="https://github.com/avaloniaui"
+﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:AvalonEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
         xmlns:local="clr-namespace:RoslynPad;assembly=RoslynPad.NetCore"

--- a/src/RoslynPad.NetCore/MainWindow.xaml
+++ b/src/RoslynPad.NetCore/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+﻿x<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:AvalonEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
         xmlns:local="clr-namespace:RoslynPad;assembly=RoslynPad.NetCore"

--- a/src/RoslynPad/App.xaml.cs
+++ b/src/RoslynPad/App.xaml.cs
@@ -1,6 +1,17 @@
-﻿namespace RoslynPad
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime;
+
+namespace RoslynPad
 {
     public partial class App
     {
+        private const string ProfileFileName = "JitProfile.profile";
+        public App()
+        {
+            ProfileOptimization.SetProfileRoot(AppDomain.CurrentDomain.BaseDirectory);
+            ProfileOptimization.StartProfile(ProfileFileName);
+        }
     }
 }

--- a/src/RoslynPad/DocumentTreeView.xaml
+++ b/src/RoslynPad/DocumentTreeView.xaml
@@ -65,7 +65,7 @@
             <Setter Property="Width"
                     Value="22" />
             <Setter Property="Padding"
-                    Value="2"/>
+                    Value="2" />
         </Style>
 
     </FrameworkElement.Resources>
@@ -84,12 +84,12 @@
                               Style="{StaticResource SearchButtonStyle}"
                               IsChecked="{Binding SearchUsingRegex}"
                               ToolTip="Use Regular Expressions"
-                              Content="{StaticResource RegularExpression}"/>
+                              Content="{StaticResource RegularExpression}" />
                 <ToggleButton DockPanel.Dock="Right"
                               Style="{StaticResource SearchButtonStyle}"
                               IsChecked="{Binding SearchFileContents}"
                               ToolTip="Search File Contents"
-                              Content="{StaticResource FileCollection}"/>
+                              Content="{StaticResource FileCollection}" />
                 <Button DockPanel.Dock="Right"
                         Style="{StaticResource SearchButtonStyle}"
                         Command="{Binding ClearSearchCommand}"

--- a/src/RoslynPad/DocumentTreeView.xaml
+++ b/src/RoslynPad/DocumentTreeView.xaml
@@ -20,7 +20,7 @@
 
         <HierarchicalDataTemplate DataType="{x:Type ui:DocumentViewModel}"
                                   ItemsSource="{Binding Children, Converter={StaticResource FilterCollectionViewConverter}}">
-            <DockPanel Margin="0 0 0 3">
+            <DockPanel Margin="0 2 0 2" VerticalAlignment="Center">
                 <ToggleButton Style="{StaticResource TreeListViewToggleStyle}" />
 
                 <Image Name="Icon"
@@ -63,7 +63,9 @@
             <Setter Property="Background"
                     Value="Transparent" />
             <Setter Property="Width"
-                    Value="16" />
+                    Value="22" />
+            <Setter Property="Padding"
+                    Value="2"/>
         </Style>
 
     </FrameworkElement.Resources>
@@ -82,12 +84,12 @@
                               Style="{StaticResource SearchButtonStyle}"
                               IsChecked="{Binding SearchUsingRegex}"
                               ToolTip="Use Regular Expressions"
-                              Content="{StaticResource RegularExpression}" />
+                              Content="{StaticResource RegularExpression}"/>
                 <ToggleButton DockPanel.Dock="Right"
                               Style="{StaticResource SearchButtonStyle}"
                               IsChecked="{Binding SearchFileContents}"
                               ToolTip="Search File Contents"
-                              Content="{StaticResource FileCollection}" />
+                              Content="{StaticResource FileCollection}"/>
                 <Button DockPanel.Dock="Right"
                         Style="{StaticResource SearchButtonStyle}"
                         Command="{Binding ClearSearchCommand}"


### PR DESCRIPTION
Added some uniform bottom and top margins for the document tree view, and made the search bar buttons icons a bit bigger to make the icons crispier and added padding:
Left = before, Right = after
![image](https://user-images.githubusercontent.com/16415180/51073000-01432480-166b-11e9-9145-54cf1f6c9698.png)
Old buttons hovered,
![image](https://user-images.githubusercontent.com/16415180/51073019-35b6e080-166b-11e9-8b83-5693d90483ca.png)
New ones: 
![image](https://user-images.githubusercontent.com/16415180/51073014-2d5ea580-166b-11e9-9f7b-b3314493aaf3.png)

Also added the multicore JIT profile optimization to improve the startup time, the profile gets stored in the exe's folder with the name of `JitProfile.profile`.

Hope you like these changes :)
