### PR TITLE
Fix MacOS unzip

### DIFF
--- a/deploy/ZipPackage.ps1
+++ b/deploy/ZipPackage.ps1
@@ -27,7 +27,7 @@ try
 
 	foreach ($file in $files)
 	{
-		[System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($archive, $file, $file.Substring($rootPath.Length)) | Out-Null
+		[System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($archive, $file, $file.Substring($rootPath.Length).Replace("\", "/")) | Out-Null
 		$file
 	}
 }


### PR DESCRIPTION
* Change "\\" (backslash) to "/" in path at the moment of creating .zip file to fix MacOS unzip issue

Fixes: #249 