### PR TITLE
Added display of selected overload index in Overload insight window.

### DIFF
--- a/src/RoslynPad.Editor.Shared/RoslynOverloadProvider.cs
+++ b/src/RoslynPad.Editor.Shared/RoslynOverloadProvider.cs
@@ -57,6 +57,7 @@ namespace RoslynPad.Editor
                 }
             };
             var contentPanel = new StackPanel();
+
             var docText = _item.DocumentationFactory(CancellationToken.None).ToTextBlock();
             if (HasContent(docText))
             {
@@ -73,6 +74,7 @@ namespace RoslynPad.Editor
             headerPanel.Children.Add(_item.SuffixDisplayParts.ToTextBlock());
             CurrentHeader = headerPanel;
             CurrentContent = contentPanel;
+            CurrentIndexText = $" {_selectedIndex + 1} of {_items.Count} ";
         }
 
 #if AVALONIA


### PR DESCRIPTION
The overload insight window now will display a string such as "1 of 4" between the arrows when in the overload insight window.

Fixes #290