### PR TITLE
ClassificationHighlightColors: create map lazily for easier customization in inherited class

### DIFF
--- a/src/RoslynPad.Editor.Shared/ClassificationHighlightColors.cs
+++ b/src/RoslynPad.Editor.Shared/ClassificationHighlightColors.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 #if AVALONIA
@@ -29,11 +30,11 @@ namespace RoslynPad.Editor
 
         public const string BraceMatchingClassificationTypeName = "brace matching";
 
-        private readonly ImmutableDictionary<string, HighlightingColor> _map;
+        private readonly Lazy<ImmutableDictionary<string, HighlightingColor>> _map;
 
         public ClassificationHighlightColors()
         {
-            _map = new Dictionary<string, HighlightingColor>
+            _map = new Lazy<ImmutableDictionary<string, HighlightingColor>>(() => new Dictionary<string, HighlightingColor>
             {
                 [ClassificationTypeNames.ClassName] = AsFrozen(TypeBrush),
                 [ClassificationTypeNames.StructName] = AsFrozen(TypeBrush),
@@ -61,12 +62,12 @@ namespace RoslynPad.Editor
                 [ClassificationTypeNames.StringLiteral] = AsFrozen(StringBrush),
                 [ClassificationTypeNames.VerbatimStringLiteral] = AsFrozen(StringBrush),
                 [BraceMatchingClassificationTypeName] = AsFrozen(BraceMatchingBrush)
-            }.ToImmutableDictionary();
+            }.ToImmutableDictionary());
         }
 
         protected virtual ImmutableDictionary<string, HighlightingColor> GetOrCreateMap()
         {
-            return _map;
+            return _map.Value;
         }
 
         public HighlightingColor GetBrush(string classificationTypeName)


### PR DESCRIPTION
If someone want to implement custom color highlighting, it's difficult to reuse `ClassificationHighlightColors`.
The reason is that the internal `_map` is created in the ctor before anything can be customized in the inherited class ctor. This forces custom implementation to create another map by copy-pasting lot of the code of the original class.

This PR delays creation of the map so that the inheriting ctor has a chance to redefine some colors.
As a result, it's now possible to do things like this:
```csharp
        class ClassificationHighlightColorsDark : ClassificationHighlightColors
        {
            public static readonly Color DefaultColor = Color.FromRgb(220, 220, 220);
            public static readonly Color TypeColor = Color.FromRgb(78, 201, 176);
            public static readonly Color KeywordColor = Color.FromRgb(86, 156, 214);

            public ClassificationHighlightColorsDark()
            {
                this.DefaultBrush = new HighlightingColor { Foreground = new SimpleHighlightingBrush(DefaultColor) };
                this.TypeBrush = new HighlightingColor { Foreground = new SimpleHighlightingBrush(TypeColor) };
                this.KeywordBrush = new HighlightingColor { Foreground = new SimpleHighlightingBrush(KeywordColor) };
            }
        }
```