### PR TITLE
Fix msbuild not restoring nuget packages if path contains spaces.

### DIFF
--- a/src/RoslynPad.Build/ExecutionHost.cs
+++ b/src/RoslynPad.Build/ExecutionHost.cs
@@ -456,7 +456,7 @@ namespace RoslynPad.Build
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var result = await ProcessUtil.RunProcess("dotnet", $"build -nologo -flp:errorsonly;logfile={errorsPath} {csprojPath}", cancellationToken).ConfigureAwait(false);
+                    var result = await ProcessUtil.RunProcess("dotnet", $"build -nologo -flp:errorsonly;logfile=\"{errorsPath}\" \"{csprojPath}\"", cancellationToken).ConfigureAwait(false);
 
                     if (result.ExitCode != 0)
                     {


### PR DESCRIPTION
Currently the path for MSBUILD restore is not escaped

This PR escapes the log path aswell as the project path.