### PR TITLE
Fix #268 - introduce IsCharIdentifier

### DIFF
--- a/src/RoslynPad.Editor.Shared/CodeTextEditor.cs
+++ b/src/RoslynPad.Editor.Shared/CodeTextEditor.cs
@@ -354,9 +354,9 @@ namespace RoslynPad.Editor
         {
             if (args.Text.Length > 0 && _completionWindow != null)
             {
-                if (!char.IsLetterOrDigit(args.Text[0]))
+                if (!IsCharIdentifier(args.Text[0]))
                 {
-                    // Whenever a non-letter is typed while the completion window is open,
+                    // Whenever no identifier letter is typed while the completion window is open,
                     // insert the currently selected element.
                     _completionWindow.CompletionList.RequestInsertion(args);
                 }
@@ -364,7 +364,15 @@ namespace RoslynPad.Editor
             // Do not set e.Handled=true.
             // We still want to insert the character that was typed.
         }
-
+        /// <summary>
+        /// Checks if a provided char is a well-known identifier
+        /// </summary>
+        /// <param name="c">The charcater to check</param>
+        /// <returns><c>true</c> if <paramref name="c"/> is a well-known identifier.</returns>
+        private bool IsCharIdentifier(char c)
+        {
+            return char.IsLetterOrDigit(c) || c == '_';
+        }
         /// <summary>
         /// Gets the document used for code completion, can be overridden to provide a custom document
         /// </summary>


### PR DESCRIPTION
fixes #268 by intoducing `private bool IsCharIdentifier(char c)` and using it on `RoslynPad.Editor.CodeTextEditor` to check if a entered character is a well-known identifier

Fixes the issue where a variable would be instantly completed when it contains an underscore `_` in it's name

Property to be completed:  
![image](https://user-images.githubusercontent.com/13602143/70508172-316e9e00-1b2e-11ea-9a2b-aad02d63bc29.png)

Pressing `_` without this fix:  
![image](https://user-images.githubusercontent.com/13602143/70508219-4a774f00-1b2e-11ea-9196-ec038d2ff9bf.png)

Pressing `_`  with the fix applied:  
![image](https://user-images.githubusercontent.com/13602143/70508230-56fba780-1b2e-11ea-81d8-c427146e171a.png)
