### PR TITLE
Add code-snipped "desktopapp"

### DIFF
--- a/src/RoslynPad.Editor.Shared/SnippetManager.cs
+++ b/src/RoslynPad.Editor.Shared/SnippetManager.cs
@@ -152,6 +152,13 @@ namespace RoslynPad.Editor
                 "Console.WriteLine",
                 "Console.WriteLine(${Selection})",
                 "if"
+            ),
+            new CodeSnippet
+            (
+                "desktopapp",
+                "#r Framework-include and await Helpers.RunWpfAsync()",
+                "#r \"framework:Microsoft.WindowsDesktop.App\"\nawait Helpers.RunWpfAsync();\n\n${Selection}",
+                "#r"
             )
         }.ToImmutableDictionary(x => x.Name);
 

--- a/src/RoslynPad.Editor.Shared/SnippetManager.cs
+++ b/src/RoslynPad.Editor.Shared/SnippetManager.cs
@@ -158,7 +158,7 @@ namespace RoslynPad.Editor
                 "desktopapp",
                 "#r Framework-include and await Helpers.RunWpfAsync()",
                 "#r \"framework:Microsoft.WindowsDesktop.App\"\nawait Helpers.RunWpfAsync();\n\n${Selection}",
-                "#r"
+                "desktopapp"
             )
         }.ToImmutableDictionary(x => x.Name);
 

--- a/src/RoslynPad.Editor.Shared/SnippetManager.cs
+++ b/src/RoslynPad.Editor.Shared/SnippetManager.cs
@@ -19,148 +19,21 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 
 namespace RoslynPad.Editor
 {
     internal sealed class SnippetManager
     {
-        internal readonly ImmutableDictionary<string, CodeSnippet> DefaultSnippets = new[]
+        internal readonly ImmutableDictionary<string, CodeSnippet> DefaultSnippets;
+
+        public SnippetManager()
         {
-            new CodeSnippet
-            (
-                "for",
-                "for loop",
-                "for (int ${counter=i} = 0; ${counter} < ${end}; ${counter}++)\n{\n\t${Selection}\n}",
-                "for"
-            ),
-            new CodeSnippet
-            (
-                "foreach",
-                "foreach loop",
-                "foreach (${var} ${element} in ${collection})\n{\n\t${Selection}\n}",
-                "foreach"
-            ),
-            new CodeSnippet
-            (
-                "if",
-                "if statement",
-                "if (${condition})\n{\n\t${Selection}\n}",
-                "if"
-            ),
-            new CodeSnippet
-            (
-                "ifnull",
-                "if-null statement",
-                "if (${condition} == null)\n{\n\t${Selection}\n}",
-                "if"
-            ),
-            new CodeSnippet
-            (
-                "ifnotnull",
-                "if-not-null statement",
-                "if (${condition} != null)\n{\n\t${Selection}\n}",
-                "if"
-            ),
-            new CodeSnippet
-            (
-                "ifelse",
-                "if-else statement",
-                "if (${condition})\n{\n\t${Selection}\n}\nelse\n{\n\t${Caret}\n}",
-                "if"
-            ),
-            new CodeSnippet
-            (
-                "while",
-                "while loop",
-                "while (${condition})\n{\n\t${Selection}\n}",
-                "while"
-            ),
-            new CodeSnippet
-            (
-                "prop",
-                "Property",
-                "public ${Type=object} ${Property=Property} { get; set; }${Caret}",
-                "event" // properties can be declared where events can be.
-            ),
-            new CodeSnippet
-            (
-                "propg",
-                "Property with private setter",
-                "public ${Type=object} ${Property=Property} { get; private set; }${Caret}",
-                "event"
-            ),
-            new CodeSnippet
-            (
-                "propfull",
-                "Property with backing field",
-                "${type} ${toFieldName(name)};\n\npublic ${type=int} ${name=Property}\n{\n\tget { return ${toFieldName(name)}; }\n\tset { ${toFieldName(name)} = value; }\n}${Caret}",
-                "event"
-            ),
-            new CodeSnippet
-            (
-                "propdp",
-                "Dependency Property",
-                "public static readonly DependencyProperty ${name}Property =" + Environment.NewLine
-                       + "\tDependencyProperty.Register(\"${name}\", typeof(${type}), typeof(${ClassName})," +
-                       Environment.NewLine
-                       + "\t                            new FrameworkPropertyMetadata());" + Environment.NewLine
-                       + "" + Environment.NewLine
-                       + "public ${type=int} ${name=Property}\n{" + Environment.NewLine
-                       + "\tget { return (${type})GetValue(${name}Property); }" + Environment.NewLine
-                       + "\tset { SetValue(${name}Property, value); }"
-                       + Environment.NewLine + "}${Caret}",
-                "event"
-            ),
-            new CodeSnippet
-            (
-                "switch",
-                "Switch statement",
-                "switch (${condition})\n{\n\t${Caret}\n}",
-                "switch"
-            ),
-            new CodeSnippet
-            (
-                "try",
-                "Try-catch statement",
-                "try\n{\n\t${Selection}\n}\ncatch (Exception)\n{\n\t${Caret}\n\tthrow;\n}",
-                "try"
-            ),
-            new CodeSnippet
-            (
-                "trycf",
-                "Try-catch-finally statement",
-                "try\n{\n\t${Selection}\n}\ncatch (Exception)\n{\n\t${Caret}\n\tthrow;\n}\nfinally\n{\n\t\n}",
-                "try"
-            ),
-            new CodeSnippet
-            (
-                "tryf",
-                "Try-finally statement",
-                "try\n{\n\t${Selection}\n}\nfinally\n{\n\t${Caret}\n}",
-                "try"
-            ),
-            new CodeSnippet
-            (
-                "using",
-                "Using statement",
-                "using (${resource=null})\n{\n\t${Selection}\n}",
-                "try"
-            ),
-            new CodeSnippet
-            (
-                "cw",
-                "Console.WriteLine",
-                "Console.WriteLine(${Selection})",
-                "if"
-            ),
-            new CodeSnippet
-            (
-                "desktopapp",
-                "#r Framework-include and await Helpers.RunWpfAsync()",
-                "#r \"framework:Microsoft.WindowsDesktop.App\"\nawait Helpers.RunWpfAsync();\n\n${Selection}",
-                "desktopapp"
-            )
-        }.ToImmutableDictionary(x => x.Name);
+            var snippets = GetGeneralSnippets();
+            snippets.AddRange(GetPlatformSnippets());
+
+            DefaultSnippets = snippets.ToImmutableDictionary(x => x.Name);
+        }
 
         public IEnumerable<CodeSnippet> Snippets => DefaultSnippets.Values;
         
@@ -169,6 +42,166 @@ namespace RoslynPad.Editor
             CodeSnippet snippet;
             DefaultSnippets.TryGetValue(name, out snippet);
             return snippet;
+        }
+
+        private List<CodeSnippet> GetGeneralSnippets()
+        {
+            var snippets = new List<CodeSnippet>
+            {
+                new CodeSnippet
+                (
+                    "for",
+                    "for loop",
+                    "for (int ${counter=i} = 0; ${counter} < ${end}; ${counter}++)\n{\n\t${Selection}\n}",
+                    "for"
+                ),
+                new CodeSnippet
+                (
+                    "foreach",
+                    "foreach loop",
+                    "foreach (${var} ${element} in ${collection})\n{\n\t${Selection}\n}",
+                    "foreach"
+                ),
+                new CodeSnippet
+                (
+                    "if",
+                    "if statement",
+                    "if (${condition})\n{\n\t${Selection}\n}",
+                    "if"
+                ),
+                new CodeSnippet
+                (
+                    "ifnull",
+                    "if-null statement",
+                    "if (${condition} == null)\n{\n\t${Selection}\n}",
+                    "if"
+                ),
+                new CodeSnippet
+                (
+                    "ifnotnull",
+                    "if-not-null statement",
+                    "if (${condition} != null)\n{\n\t${Selection}\n}",
+                    "if"
+                ),
+                new CodeSnippet
+                (
+                    "ifelse",
+                    "if-else statement",
+                    "if (${condition})\n{\n\t${Selection}\n}\nelse\n{\n\t${Caret}\n}",
+                    "if"
+                ),
+                new CodeSnippet
+                (
+                    "while",
+                    "while loop",
+                    "while (${condition})\n{\n\t${Selection}\n}",
+                    "while"
+                ),
+                new CodeSnippet
+                (
+                    "prop",
+                    "Property",
+                    "public ${Type=object} ${Property=Property} { get; set; }${Caret}",
+                    "event" // properties can be declared where events can be.
+                ),
+                new CodeSnippet
+                (
+                    "propg",
+                    "Property with private setter",
+                    "public ${Type=object} ${Property=Property} { get; private set; }${Caret}",
+                    "event"
+                ),
+                new CodeSnippet
+                (
+                    "propfull",
+                    "Property with backing field",
+                    "${type} ${toFieldName(name)};\n\npublic ${type=int} ${name=Property}\n{\n\tget { return ${toFieldName(name)}; }\n\tset { ${toFieldName(name)} = value; }\n}${Caret}",
+                    "event"
+                ),
+                new CodeSnippet
+                (
+                    "propdp",
+                    "Dependency Property",
+                    "public static readonly DependencyProperty ${name}Property =" + Environment.NewLine
+                           + "\tDependencyProperty.Register(\"${name}\", typeof(${type}), typeof(${ClassName})," +
+                           Environment.NewLine
+                           + "\t                            new FrameworkPropertyMetadata());" + Environment.NewLine
+                           + "" + Environment.NewLine
+                           + "public ${type=int} ${name=Property}\n{" + Environment.NewLine
+                           + "\tget { return (${type})GetValue(${name}Property); }" + Environment.NewLine
+                           + "\tset { SetValue(${name}Property, value); }"
+                           + Environment.NewLine + "}${Caret}",
+                    "event"
+                ),
+                new CodeSnippet
+                (
+                    "switch",
+                    "Switch statement",
+                    "switch (${condition})\n{\n\t${Caret}\n}",
+                    "switch"
+                ),
+                new CodeSnippet
+                (
+                    "try",
+                    "Try-catch statement",
+                    "try\n{\n\t${Selection}\n}\ncatch (Exception)\n{\n\t${Caret}\n\tthrow;\n}",
+                    "try"
+                ),
+                new CodeSnippet
+                (
+                    "trycf",
+                    "Try-catch-finally statement",
+                    "try\n{\n\t${Selection}\n}\ncatch (Exception)\n{\n\t${Caret}\n\tthrow;\n}\nfinally\n{\n\t\n}",
+                    "try"
+                ),
+                new CodeSnippet
+                (
+                    "tryf",
+                    "Try-finally statement",
+                    "try\n{\n\t${Selection}\n}\nfinally\n{\n\t${Caret}\n}",
+                    "try"
+                ),
+                new CodeSnippet
+                (
+                    "using",
+                    "Using statement",
+                    "using (${resource=null})\n{\n\t${Selection}\n}",
+                    "try"
+                ),
+                new CodeSnippet
+                (
+                    "cw",
+                    "Console.WriteLine",
+                    "Console.WriteLine(${Selection})",
+                    "if"
+                )
+            };
+            return snippets;
+        }
+
+        private List<CodeSnippet> GetPlatformSnippets()
+        {
+            var snippets = new List<CodeSnippet>();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                snippets.AddRange(GetWindowsSnippets());
+            }
+            return snippets;
+        }
+
+        private List<CodeSnippet> GetWindowsSnippets()
+        {
+            return new List<CodeSnippet>
+            {
+                new CodeSnippet
+                (
+                    "desktopapp",
+                    "#r Framework-include and await Helpers.RunWpfAsync()",
+                    "#r \"framework:Microsoft.WindowsDesktop.App\"\nawait Helpers.RunWpfAsync();\n\n${Selection}",
+                    "#r"
+                )
+            };
         }
     }
 }


### PR DESCRIPTION
Added snippet "desktopapp"

i test a lot of stuff using RoslynPad and sometimes need to create a Desktopapp-environment.

![desktopapp-snippet example](https://puu.sh/F4jEk.gif)

i guess this could be changed to only be visible in Windows-Builds (any directions on where to setup platform specific snippets?)