### PR TITLE
Ensure build succeeeds even without .net48 SDK

### DIFF
--- a/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
+++ b/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\RoslynPad.Editor.Shared\**\*.cs">

--- a/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
+++ b/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\RoslynPad.Editor.Shared\**\*.cs">

--- a/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
+++ b/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
@@ -14,6 +14,6 @@
     <ProjectReference Include="..\RoslynPad.Roslyn\RoslynPad.Roslyn.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
+++ b/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
@@ -13,4 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RoslynPad.Roslyn\RoslynPad.Roslyn.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This should have worked, but the temporary project created by
WPF still fails unless you have the .NET4.8 targeting pack :(

Might still be worth keeping as the underlying WPF issue might be
solved at some point?