### PR TITLE
Ensure script execution WorkingDirectory matches current script path

### DIFF
--- a/src/RoslynPad.Build/ExecutionHostParameters.cs
+++ b/src/RoslynPad.Build/ExecutionHostParameters.cs
@@ -26,7 +26,7 @@ namespace RoslynPad.Build
         public string NuGetConfigPath { get; }
         public ImmutableArray<string> Imports { get; set; }
         public ImmutableArray<string> DisabledDiagnostics { get; }
-        public string WorkingDirectory { get; }
+        public string WorkingDirectory { get; set; }
         public bool CheckOverflow { get; }
         public bool AllowUnsafe { get; }
     }

--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -670,6 +670,11 @@ namespace RoslynPad.UI
                 var code = await GetCode(cancellationToken).ConfigureAwait(true);
                 if (_executionHost != null)
                 {
+                    // Make sure the execution working directory matches the current script path
+                    // which may have chaned since we loaded.
+                    if (_executionHostParameters.WorkingDirectory != WorkingDirectory)
+                        _executionHostParameters.WorkingDirectory = WorkingDirectory;
+
                     await _executionHost.ExecuteAsync(code, ShowIL, OptimizationLevel).ConfigureAwait(true);
                 }
             }

--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -671,7 +671,7 @@ namespace RoslynPad.UI
                 if (_executionHost != null)
                 {
                     // Make sure the execution working directory matches the current script path
-                    // which may have chaned since we loaded.
+                    // which may have changed since we loaded.
                     if (_executionHostParameters.WorkingDirectory != WorkingDirectory)
                         _executionHostParameters.WorkingDirectory = WorkingDirectory;
 


### PR DESCRIPTION
There seems to be a timing issue where the opened document is null while
the initial execution host parameters are created. This might not be the
best way, but making the `WorkingDirectory` writable and ensuring it
matches the current document WorkingDirectory seems to fix the issue
around relative path file loading.

Fix #350