### PR TITLE
Fixed issue where the lightbulb doesn't refresh automatically

### DIFF
--- a/src/RoslynPad.Editor.Shared/ContextActionsRenderer.cs
+++ b/src/RoslynPad.Editor.Shared/ContextActionsRenderer.cs
@@ -209,7 +209,7 @@ namespace RoslynPad.Editor
                 return;
             }
 
-            //_contextMenu.SetItems(_actions!);
+            _contextMenu.SetItems(_actions!);
             _bulbMargin.LineNumber = _editor.TextArea.Caret.Line;
         }
 


### PR DESCRIPTION
When moving the caret, the actions of the light bulb isn't automatically refreshed. Found a line of code that was commented, after uncommenting it worked again.