### PR TITLE
Exposed SearchReplacePanel of the Windows CodeTextEditor to allow its customization.

### DIFF
--- a/src/RoslynPad.Editor.Windows/CodeTextEditor.Windows.cs
+++ b/src/RoslynPad.Editor.Windows/CodeTextEditor.Windows.cs
@@ -6,6 +6,8 @@ namespace RoslynPad.Editor
 {
     partial class CodeTextEditor
     {
+        private SearchReplacePanel? _searchReplacePanel;
+
         partial void Initialize()
         {
             ShowLineNumbers = true;
@@ -14,8 +16,10 @@ namespace RoslynPad.Editor
             MouseHoverStopped += OnMouseHoverStopped;
 
             ToolTipService.SetInitialShowDelay(this, 0);
-            SearchReplacePanel.Install(this);
+            _searchReplacePanel = SearchReplacePanel.Install(this);
         }
+
+        public SearchReplacePanel SearchReplacePanel => _searchReplacePanel!;
 
         partial void InitializeToolTip()
         {


### PR DESCRIPTION
I wanted to implemented a dark-mode theme for the editor, so I needed to customize search result highlight colors as white was not readable on bright green, so I'm storing and exposing the SearchReplacePanel as a property.

Please let me know if I'll need to make any changes.

Btw, the dark-mode theme can be found [in this gist](https://gist.github.com/gmanny/d40f71f0e38a6a9da673a2e05117b847). It's based on default Visual Studio colors.