### PR TITLE
Fix Document switching not showing names #354

### DIFF
--- a/src/RoslynPad/MainWindow.xaml
+++ b/src/RoslynPad/MainWindow.xaml
@@ -89,6 +89,11 @@
                             <TextBlock Text="{Binding Content.Title}" />
                         </DataTemplate>
                     </dock:DockingManager.DocumentPaneMenuItemHeaderTemplate>
+                    <dock:DockingManager.LayoutItemContainerStyle>
+                        <Style TargetType="{x:Type dock:LayoutItem}">
+                            <Setter Property="Title" Value="{Binding Model.Title}"/>
+                        </Style>
+                    </dock:DockingManager.LayoutItemContainerStyle>
                     <dock:LayoutRoot>
                         <dock:LayoutPanel Orientation="Horizontal">
                             <dock:LayoutAnchorablePane Name="Documents"


### PR DESCRIPTION
I fixed the bug when switching from one open document to another with Ctrl+Tab, no name was shown 🙂 
Fixes #354