### PR TITLE
Allow tweaking of the editor from the json settings file for code formatting and editor behaviors

### DIFF
--- a/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
+++ b/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace RoslynPad.UI
 {
@@ -21,5 +22,7 @@ namespace RoslynPad.UI
         double? WindowFontSize { get; set; }
         bool FormatDocumentOnComment { get; set; }
         string EffectiveDocumentPath { get; }
+        IDictionary<string, string>? AvalonTextEditorOptionOverrides {get; set;}
+        IDictionary<string, string>? CSharpFormattingOptionOverrides { get; set; }
     }
 }

--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Scripting;
@@ -420,7 +421,7 @@ namespace RoslynPad.UI
         private async Task FormatDocumentAsync()
         {
             var document = MainViewModel.RoslynHost.GetDocument(DocumentId);
-            var formattedDocument = await Formatter.FormatAsync(document!).ConfigureAwait(false);
+            var formattedDocument = await Formatter.FormatAsync(document!, MainViewModel.DocumentFormatOptions).ConfigureAwait(false);
             MainViewModel.RoslynHost.UpdateDocument(formattedDocument);
         }
 

--- a/src/RoslynPad/DocumentView.xaml.cs
+++ b/src/RoslynPad/DocumentView.xaml.cs
@@ -90,6 +90,9 @@ namespace RoslynPad
                 this);
 
             Editor.Document.TextChanged += (o, e) => _viewModel.OnTextChanged();
+            var doc = _viewModel.MainViewModel.RoslynHost.GetDocument(documentId);
+            var settings = _viewModel.MainViewModel.Settings;
+            MainViewModel.ApplyDictionaryOverObject(settings.AvalonTextEditorOptionOverrides, Editor.Options);
         }
 
         private void OnReadInput()


### PR DESCRIPTION
Fantastic tool.  I have seen some requests in the past for being able to control certain settings and a desire to not clutter the UI or add a settings page.  If this PR is desired let me know and I will clean it up.  I am sure functions are not in the best places (probably would create a new class for the generic assist tool) and may be breaking some of the MVVM model.

This is a small step towards more flexibility without changing the UI or guaranteeing a specific setting to work.

To start this allows you to add to your RoslynPad.json file a block like
```json
 "avalonTextEditorOptionOverrides": {
    "ConvertTabsToSpaces": "False"
  },
  "cSharpFormattingOptionOverrides": {
    "NewLinesForBracesInTypes": "False",
    "NewLineForElse": "False",
    "NewLineForCatch": "False",
    "NewLineForClausesInQuery": "False",
    "NewLineForFinally": "False",
    "NewLineForMembersInAnonymousTypes": false,
    "NewLineForMembersInObjectInit": false,
    "NewLinesForBracesInAccessors": "False",
    "NewLinesForBracesInAnonymousMethods": "False",
    "NewLinesForBracesInAnonymousTypes": "False",
    "NewLinesForBracesInControlBlocks": "False",
    "NewLinesForBracesInLambdaExpressionBody": "False",
    "NewLinesForBracesInMethods":  true,
    "NewLinesForBracesInObjectCollectionArrayInitializers": "False",
    "NewLinesForBracesInProperties": "False"
  }
```

The code gives some new generics to hopefully make it easier to allow setting groups of settings without actually adding the code for every specific setting.  It uses reflection to take each key in the dictionary for a specific setting type that the user sets and then tries to apply it properly.   It only works with basic types (strings and valuetypes) but there is no reason it couldn't be expanded to more complex structures.   Could this let someone set something that might break existing behavior? Sure.  I would slap a warning on the documentation ( if there is docs? ) that if you set a setting it might break some existing functionality.   It could easily support blacklisting certain settings from being set.

This also allows for as options change to not require code changes on your side.

Finally, I edited the settings reader to be more friendly  more newtonsoft/json esk.

So let me know if this is wanted, if you can guide where I should place certain calls If obvious will make my cleanup easier.  

Closes #358