### PR TITLE
Upgrade Roslynpad to AvaloniaEdit 12.0.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,4 +35,8 @@
       <_ComputedTargetFrameworkMoniker>$(Original_ComputedTargetFrameworkMoniker)</_ComputedTargetFrameworkMoniker>
     </PropertyGroup>
   </Target>
+  <PropertyGroup Condition=" '$([System.OperatingSystem]::IsWindows())' == 'false' AND '$(UseWPF)' == 'true' ">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,27 +4,28 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <DotNetExtensionsVersion>10.0.1</DotNetExtensionsVersion>
+    <DotNetExtensionsVersion>10.0.5</DotNetExtensionsVersion>
     <RoslynVersion>5.0.0</RoslynVersion>
     <!-- https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-tools/NuGet/Microsoft.CodeAnalysis.LanguageServer.Protocol/ -->
     <RoslynPrivateVersion>5.0.0-2.25567.12</RoslynPrivateVersion>
-    <AvaloniaVersion>11.3.10</AvaloniaVersion>
-    <NuGetVersion>7.0.1</NuGetVersion>
+    <AvaloniaVersion>12.0.1</AvaloniaVersion>
+    <NuGetVersion>7.0.3</NuGetVersion>
     <MessagePackVersion>3.1.4</MessagePackVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AvalonEdit" Version="6.3.1.120" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.4" />
     <PackageVersion Include="AvalonLibrary" Version="4.0.1" />
-    <PackageVersion Include="DialogHost.Avalonia" Version="0.10.3" />
-    <PackageVersion Include="Dirkster.AvalonDock" Version="4.72.1" />
-    <PackageVersion Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.1" />
-    <PackageVersion Include="Dock.Avalonia" Version="11.3.8" />
-    <PackageVersion Include="Dock.Model.Avalonia" Version="11.3.8" />
-    <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="11.3.8" />
+    <PackageVersion Include="DialogHost.Avalonia" Version="0.12.0" />
+    <PackageVersion Include="Dirkster.AvalonDock" Version="4.73.0" />
+    <PackageVersion Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.73.0" />
+    <PackageVersion Include="Dock.Avalonia" Version="12.0.0.1" />
+    <PackageVersion Include="Dock.Model.Avalonia" Version="12.0.0.1" />
+    <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="12.0.0.1" />
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="$(RoslynVersion)" />
@@ -40,9 +41,11 @@
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Commands" Version="$(NuGetVersion)" />
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersion)" />
+    <PackageVersion Include="RoslynPad.Editor.Avalonia" Version="4.12.1" />
+    <PackageVersion Include="RoslynPad.Editor.Windows" Version="4.12.1" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="$(DotNetExtensionsVersion)" />
     <PackageVersion Include="System.Reactive.Core" Version="6.1.0" />
     <PackageVersion Include="System.Reactive.Linq" Version="6.1.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100"
+    "version": "10.0.201"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.134",

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+    <Import Project="../Directory.Build.props" />
     <PropertyGroup>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,1 +1,9 @@
-<Project />
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <Import Project="../Directory.Packages.props" />
+  <ItemGroup>
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
+  </ItemGroup>
+</Project>

--- a/samples/RoslynPadAvaloniaReplSample/Program.cs
+++ b/samples/RoslynPadAvaloniaReplSample/Program.cs
@@ -5,7 +5,8 @@ namespace RoslynPadAvaloniaReplSample;
 internal static class Program
 {
     public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
-        .UsePlatformDetect();
+        .UsePlatformDetect()
+        .LogToTrace();
 
     public static int Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);

--- a/samples/RoslynPadAvaloniaReplSample/RoslynPadAvaloniaReplSample.csproj
+++ b/samples/RoslynPadAvaloniaReplSample/RoslynPadAvaloniaReplSample.csproj
@@ -1,15 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <UseProjectReferences Condition="'$(UseProjectReferences)' == ''">true</UseProjectReferences>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.4" />
-    <PackageReference Include="RoslynPad.Editor.Avalonia" Version="4.12.1" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Diagnostics" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReferences)' != 'true'">
+    <PackageReference Include="RoslynPad.Editor.Avalonia" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\src\RoslynPad.Editor.Avalonia\RoslynPad.Editor.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\RoslynPad.Roslyn\RoslynPad.Roslyn.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/RoslynPadReplSample/RoslynPadReplSample.csproj
+++ b/samples/RoslynPadReplSample/RoslynPadReplSample.csproj
@@ -1,12 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>$(DefaultTargetFramework)-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
+    <UseProjectReferences Condition="'$(UseProjectReferences)' == ''">true</UseProjectReferences>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(OS)' != 'Windows_NT'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="RoslynPad.Editor.Windows" Version="4.12.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
+
+  <ItemGroup Condition="'$(UseProjectReferences)' != 'true'">
+    <PackageReference Include="RoslynPad.Editor.Windows" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseProjectReferences)' == 'true'">
+    <ProjectReference Include="..\..\src\RoslynPad.Editor.Windows\RoslynPad.Editor.Windows.csproj" />
+    <ProjectReference Include="..\..\src\RoslynPad.Roslyn\RoslynPad.Roslyn.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" />
   </ItemGroup>
 </Project>

--- a/src/RoslynPad.Avalonia/DocumentView.axaml
+++ b/src/RoslynPad.Avalonia/DocumentView.axaml
@@ -134,7 +134,7 @@
       <TextBox Name="NuGetSearch"
                BorderBrush="#eeeeee"
                Text="{Binding NuGet.SearchTerm}"
-               Watermark="{OnPlatform Search NuGet (Ctrl+T), macOS=Search NuGet (⌘ T)}"
+               PlaceholderText="{OnPlatform Search NuGet (Ctrl+T), macOS=Search NuGet (⌘ T)}"
                Width="200" />
       <Decorator VerticalAlignment="Center">
         <CheckBox IsChecked="{Binding NuGet.Prerelease}"

--- a/src/RoslynPad.Editor.Windows/Shared/CodeEditorCompletionWindow.cs
+++ b/src/RoslynPad.Editor.Windows/Shared/CodeEditorCompletionWindow.cs
@@ -10,7 +10,7 @@ public partial class CodeEditorCompletionWindow : CompletionWindow
         _isSoftSelectionActive = true;
         CompletionList.SelectionChanged += CompletionListOnSelectionChanged;
 
-        Initialize();
+        this.Loaded += (_,_) => Initialize();
     }
 
     partial void Initialize();


### PR DESCRIPTION
Fixes #626

This pull request introduces several important updates to dependencies, build configuration, and sample project files to improve cross-platform support, enable easier switching between package and project references, and update to newer library versions. The changes primarily focus on modernizing dependencies, enhancing sample project flexibility, and ensuring compatibility with the latest .NET SDKs and Avalonia versions.

**Dependency and SDK Updates:**

- Upgraded multiple package versions, including `Avalonia`, `Avalonia.AvaloniaEdit`, `Dock.Avalonia`, `DialogHost.Avalonia`, `Dirkster.AvalonDock`, `Newtonsoft.Json`, and others, to their latest releases in `Directory.Packages.props`. Also updated the .NET SDK version in `global.json` from `10.0.100` to `10.0.201`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R28) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L43-R48) [[3]](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3)

**Sample Project Improvements:**

- Modified sample project files (`RoslynPadAvaloniaReplSample.csproj`, `RoslynPadReplSample.csproj`) to support switching between using NuGet package references and direct project references via the `UseProjectReferences` property. This enables easier local development and testing of source changes. [[1]](diffhunk://#diff-d3d1ce1af3fcbd0bfa44a27ee47ec62090af23e8b8e228679c1f34c712ea0cf8L3-R23) [[2]](diffhunk://#diff-de84c06195aa9b6e8caa145383eb26cd8a50830967b5eb4a720811391ac4323fL3-R19)
- Updated sample build props and packages files to import shared configuration and enable central package management. Added `Avalonia.Fonts.Inter` package for sample projects. [[1]](diffhunk://#diff-948ca9f549e2111256790ff9d494e3d7f37f00b111f72b2ea8bb5ca5725465e4R2) [[2]](diffhunk://#diff-8f89fce241ca6b7cc6aadbd5301d1568306ec7cc6b53117a6ed2b48816991e11L1-R9)

**Cross-Platform and Build Configuration:**

- Improved cross-platform build support by setting appropriate runtime identifiers and self-contained settings for WPF and Avalonia projects when building on non-Windows systems. [[1]](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcR38-R41) [[2]](diffhunk://#diff-de84c06195aa9b6e8caa145383eb26cd8a50830967b5eb4a720811391ac4323fL3-R19)

**UI and Usability Enhancements:**

- Updated `DocumentView.axaml` to use the `PlaceholderText` property instead of the deprecated `Watermark` property for the NuGet search box, aligning with recent Avalonia UI changes.
- Enabled trace logging in the Avalonia sample app for easier debugging.

